### PR TITLE
Update plugin for Freesound APIv2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,77 @@
+# ------------------------------------------------
+# com.occulkot.Freesound.xrnx
+# ------------------------------------------------
+credentials.lua
+
+# ------------------------------------------------
+# EVERYTHING ELSE
+# ------------------------------------------------
+
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Compiled Lua sources
+luac.out
+
+# luarocks build files
+*.src.rock
+*.zip
+*.tar.gz
+
+# Object files
+*.o
+*.os
+*.ko
+*.obj
+*.elf
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+*.def
+*.exp
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-[Renoise](http://renoise.com) Tool for accessing http://freesound.org library
+# Summary
+
+[Renoise](http://renoise.com) tool for accessing http://freesound.org library.
+
+# Usage instructions
+
+1. Follow the instructions [here](http://www.freesound.org/docs/api/authentication.html#token-authentication) to get a Freesound API key.
+1. Clone this repository.
+1. Open `credentials.lua`. Edit the line with `YOUR_API_KEY` with your actual API key. For instance, if your API key were `123abc`, that line would read:
+```
+credentials.token = "123abc"
+```
+1. In your file browser, drag the entire `com.occulkot.Freesound.xrnx` directory and drop it on top of the icon of your Renoise application.
+1. Access the tool in Renoise via `Tools > Freesound > Browse samples`, and update settings via `Tools > Freesound > Settings`.

--- a/credentials.lua
+++ b/credentials.lua
@@ -1,0 +1,5 @@
+local credentials = {}
+
+credentials.token = "YOUR_API_KEY"
+
+return credentials

--- a/main.lua
+++ b/main.lua
@@ -42,6 +42,7 @@ renoise.tool():add_menu_entry {
    end
                               }
 
+
 -- variables
 local main_url = "https://freesound.org/apiv2/"
 local credentials = require("credentials")
@@ -504,4 +505,12 @@ function show_search_dialog()
          status_bar
       }
                                    )
+end
+
+-- keybindings
+local keybinding_name = "Global:Tools:Freesound"
+local keybinding_exists = renoise.tool():has_keybinding(keybinding_name)
+if not keybinding_exists then
+  local keybinding_definition_table = {name = keybinding_name, invoke = show_search_dialog}
+  renoise.tool():add_keybinding(keybinding_definition_table)
 end

--- a/main.lua
+++ b/main.lua
@@ -176,7 +176,7 @@ function search(name, tag, author, sort, page)
       url = url .. filtr .. '&'
    end
    url = url .. 'page=' .. page
-   url = url .. "&fields=id,type,duration,previews,original_filename,username,url,images"
+   url = url .. "&fields=id,type,duration,previews,name,username,url,images"
    HTTP:get(url, {}, parse_results)
 end
 
@@ -209,7 +209,7 @@ function parse_results(data, status, xml)
          type = sampl['type'],
          duration = string.format("%.3f", sampl['duration']),
          preview = sampl['preview-lq-ogg'],
-         name = sampl['original_filename'],
+         name = sampl['name'],
          author = sampl['username'],
          url = sampl['url'],
          img = icon,

--- a/main.lua
+++ b/main.lua
@@ -214,7 +214,7 @@ function parse_results(data, status, xml)
          url = sampl['url'],
          img = icon,
       }
-      download_img(sampl['waveform_m'], icon, samples[sampl['id']])
+      download_img(sampl['images']['waveform_m'], icon, samples[sampl['id']])
    end
    vb.views.sample_list:add_child(show_sample_table(samples))
    vb.views.results.text = string.format("%d results", data['count'])

--- a/main.lua
+++ b/main.lua
@@ -74,7 +74,6 @@ local page = 1
 
 -- sample manipulation
 function download_sample(sample)
-   local download_info = nil
    local sample_name = string.format("%d-%s.%s", sample['id'], sample['name'], sample['type'])
    local sample_name = string.gsub(string.gsub(sample_name, ' ', ''), '"', '')
    local final_name = ''
@@ -83,6 +82,16 @@ function download_sample(sample)
    else
      final_name = os.tmpname()  ..'.'.. sample['type']
    end
+   
+   local sample_name = string.format("%d-%s.%s", sample['id'], sample['name'], sample['type'])
+   local sample_name = string.gsub(string.gsub(sample_name, ' ', ''), '"', '')
+   local final_name = ''
+   if options.SavePath.value ~= '' then
+     final_name = options.SavePath.value .. sample_name
+   else
+     final_name = os.tmpname()  ..'.'.. sample['type']
+   end
+
    local suc = function (fname, costam, costam)
       os.move(fname, final_name)
       status.text = 'success'
@@ -101,11 +110,10 @@ function download_sample(sample)
       end
    end
    local erro = function (error)
-      status.text="Error while downloading " .. sample_name
+      status.text="Error while downloading " .. sample['name']
    end
-   local id = sample['id']
-   status.text = "downloading " .. sample_name .. ' please wait'
-   local uri = main_url .. 'sounds/' .. id .. '/serve/?api_key=' .. api_key
+   status.text = "downloading " .. sample['name']
+   local uri = sample['hq_sample']
    Request({
               url=uri, 
               method=Request.GET, 
@@ -116,8 +124,7 @@ function download_sample(sample)
 end
 
 
-function preview_sample(sample)
-   
+function preview_sample(sample)   
    if options.Executable.value == '' and options.ExecutableInfo.value == '' then
       local war = vb:multiline_text{width=200, height=100, text= [[ You dont have sample player configured
 Renoise will use default player provided by system ]]}
@@ -209,6 +216,7 @@ function parse_results(data, status, xml)
          type = sampl['type'],
          duration = string.format("%.3f", sampl['duration']),
          preview = sampl['previews']['preview-lq-mp3'],
+         hq_sample = sampl['previews']['preview-hq-mp3'],
          name = sampl['name'],
          author = sampl['username'],
          url = sampl['url'],

--- a/main.lua
+++ b/main.lua
@@ -208,7 +208,7 @@ function parse_results(data, status, xml)
          id = sampl['id'],
          type = sampl['type'],
          duration = string.format("%.3f", sampl['duration']),
-         preview = sampl['preview-lq-ogg'],
+         preview = sampl['previews']['preview-lq-mp3'],
          name = sampl['name'],
          author = sampl['username'],
          url = sampl['url'],
@@ -316,7 +316,7 @@ function show_settings()
                                                ff,
                                                vb:button{text="Browse for program",
                                                          pressed = function ()
-                                                            local t = renoise.app():prompt_for_filename_to_read({"*"}, 'Select sample player')
+                                                            local t = renoise.app():prompt_for_filename_to_read({"mp3"}, 'Select sample player')
                                                             ff.value = t
                                                end},
                                             },

--- a/main.lua
+++ b/main.lua
@@ -43,11 +43,12 @@ renoise.tool():add_menu_entry {
                               }
 
 -- variables
-local main_url = "http://freesound.org/api/"
-local api_key = "b79e90926df54fa98a5759d77eb55a29"
+local main_url = "https://freesound.org/apiv2/"
+local credentials = require("credentials")
 local status = nil
 
 local sort_orders = {
+  "Sort by a relevance score returned by our search engine (default).",
    "Sort by the number of downloads, most downloaded sounds first.",
    "Same as above, but least downloaded sounds first.",
    "Sort by the duration of the sounds, longest sounds first.",
@@ -59,6 +60,7 @@ local sort_orders = {
 }
 
 local sort_pars = {
+  "score",
    "downloads_desc",
    "downloads_asc",
    "duration_desc",
@@ -155,9 +157,9 @@ end
 
 -- freesound api
 function search(name, tag, author, sort, page)
-   local url = main_url  .. 'sounds/search/?api_key=' .. api_key .. "&"
+   local url = main_url  .. 'search/text/?token=' .. credentials.token .. "&"
    local pars = {['tag']='',}
-   pars['name'] = 'q=' .. name .. ''
+   pars['name'] = 'query=' .. name .. ''
    local filtr = ''
    if tag ~= "" then
       filtr = filtr .. ' tag:' .. tag .. ''
@@ -166,14 +168,14 @@ function search(name, tag, author, sort, page)
       filtr = filtr .. ' username:' .. author .. ''
    end
    if filtr ~= "" then
-      pars['filtr'] = 'f=' .. filtr
+      pars['filter'] = 'filter=' .. filtr
    end
    
-   pars['sort'] = 's=' .. sort_pars[sort] .. ''
+   pars['sort'] = 'sort=' .. sort_pars[sort] .. ''
    for i, filtr in pairs(pars) do
       url = url .. filtr .. '&'
    end
-   url = url .. 'p=' .. page
+   url = url .. 'page=' .. page
    HTTP:get(url, {}, parse_results)
 end
 

--- a/main.lua
+++ b/main.lua
@@ -176,6 +176,7 @@ function search(name, tag, author, sort, page)
       url = url .. filtr .. '&'
    end
    url = url .. 'page=' .. page
+   url = url .. "&fields=id,type,duration,previews,original_filename,username,url,images"
    HTTP:get(url, {}, parse_results)
 end
 
@@ -201,7 +202,7 @@ local sample_table= ""
 function parse_results(data, status, xml)
    local data = json.decode(data)
    samples = {}
-   for i, sampl in pairs(data['sounds']) do
+   for i, sampl in pairs(data['results']) do
       local icon = 'fetching.png'
       samples[sampl['id']] = {
          id = sampl['id'],
@@ -209,9 +210,8 @@ function parse_results(data, status, xml)
          duration = string.format("%.3f", sampl['duration']),
          preview = sampl['preview-lq-ogg'],
          name = sampl['original_filename'],
-         author = sampl['user']['username'],
-         preview = sampl['preview-lq-ogg'],
-         url = sampl['ref'],
+         author = sampl['username'],
+         url = sampl['url'],
          img = icon,
       }
       download_img(sampl['waveform_m'], icon, samples[sampl['id']])

--- a/main.lua
+++ b/main.lua
@@ -217,8 +217,9 @@ function parse_results(data, status, xml)
       download_img(sampl['waveform_m'], icon, samples[sampl['id']])
    end
    vb.views.sample_list:add_child(show_sample_table(samples))
-   vb.views.results.text = string.format("%d results", data['num_results'])
-   vb.views.pages.text = string.format("%d/%d pages", page, data['num_pages'])
+   vb.views.results.text = string.format("%d results", data['count'])
+   -- TODO: store "next" and "prev" links
+   -- vb.views.pages.text = string.format("%d/%d pages", page, data['num_pages'])
    if page > 1 then
       vb.views.prev_button.active = true
    else

--- a/main.lua
+++ b/main.lua
@@ -227,8 +227,7 @@ function parse_results(data, status, xml)
    end
    vb.views.sample_list:add_child(show_sample_table(samples))
    vb.views.results.text = string.format("%d results", data['count'])
-   -- TODO: store "next" and "prev" links
-   -- vb.views.pages.text = string.format("%d/%d pages", page, data['num_pages'])
+
    if page > 1 then
       vb.views.prev_button.active = true
    else


### PR DESCRIPTION
I noticed that the plugin doesn't work any longer; it turned out to be because the first version of the Freesound API has been retired. This pull request updates the plugin to work with Freesound's APIv2.

In addition to that, it makes a few other changes. Those include:
* requiring the user to use their own Freesound API key instead of a shared one across all plugin users
* sorting search results by Freesound "score" by default
* adding support for Renoise keybindings for surfacing the search UI